### PR TITLE
[core/api] add authorization_required hook to check bearer tokens

### DIFF
--- a/server/hooks.py
+++ b/server/hooks.py
@@ -1,0 +1,32 @@
+import falcon
+
+from uuid import UUID
+
+
+def authorization_required(req, resp, resource, params):
+    """Require Authorization header before accepting clients request.
+    The Authorization header must include the session identifier
+    retrieved during a client login.
+
+    When this hook is used, the Authorization header is extracted as
+    `token` kwarg, and is available in the responder function.
+
+    Args:
+        req: Falcon `Request` object
+        resp: Falcon `Response` object
+        resource: Falcon `Resource` after routing
+        params: Parameters to pass to a responder function
+    Raises:
+        HTTPUnauthorized: if the Authorization header is empty or not valid
+    """
+    if req.auth is None:
+        raise falcon.HTTPUnauthorized("Authentication credentials were not provided")
+
+    try:
+        # Extract the bearer token and validate if it's a valid UUID
+        token = req.auth.split(" ")[1]
+        UUID(token, version=4)
+    except (ValueError, IndexError, AttributeError):
+        raise falcon.HTTPUnauthorized("Incorrect authentication credentials")
+
+    params["token"] = token

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,27 @@
 import pytest
+import falcon
 
 from falcon import testing
 from server.api import create
+from server.hooks import authorization_required
 
 
 @pytest.fixture
 def client():
     """Testing API client"""
     return testing.TestClient(create())
+
+
+@pytest.fixture
+def hooks_client():
+    """Testing API client with a fake app"""
+
+    class Responder(object):
+        @falcon.before(authorization_required)
+        def on_get(self, req, resp, token):
+            resp.media = {"token": token}
+            resp.status = falcon.HTTP_200
+
+    api = falcon.API()
+    api.add_route("/hooks/authorization_required", Responder())
+    return testing.TestClient(api)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,26 @@
+def test_authorization_required(hooks_client):
+    """Should return a 401 if the Authorization header is missing"""
+    result = hooks_client.simulate_get("/hooks/authorization_required")
+    assert result.status_code == 401
+
+
+def test_authorization_is_valid(hooks_client):
+    """Should return a 401 if the Authorization header doesn't contain a valid UUID"""
+    headers = {"Authorization": "Test Token"}
+    result = hooks_client.simulate_get("/hooks/authorization_required", headers=headers)
+    assert result.status_code == 401
+
+
+def test_authorization_is_valid_without_split(hooks_client):
+    """Should return a 401 if the Authorization header doesn't contain a valid UUID"""
+    headers = {"Authorization": "Token"}
+    result = hooks_client.simulate_get("/hooks/authorization_required", headers=headers)
+    assert result.status_code == 401
+
+
+def test_authorization_success(hooks_client):
+    """Should return a 401 if the Authorization header doesn't contain a valid UUID"""
+    headers = {"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"}
+    result = hooks_client.simulate_get("/hooks/authorization_required", headers=headers)
+    assert result.status_code == 200
+    assert result.json == {"token": "127d9a48-927a-43f3-a3e3-842f3f2b7393"}


### PR DESCRIPTION
### Overview

Add `authorization_required` hook that checks:
* If `Authorization` header is set
* If `Authorization` header has a valid UUID (access token) that is passed to Falcon responder