### PR TITLE
Implement ARM and DISARM endpoints

### DIFF
--- a/server/api.py
+++ b/server/api.py
@@ -1,6 +1,6 @@
 import falcon
 
-from .resources import Authentication
+from .resources import Authentication, AlarmsResource
 
 
 def create():
@@ -12,5 +12,6 @@ def create():
     """
     # Initialize the API
     api = falcon.API()
-    api.add_route("/api/v0/auth", Authentication())
+    api.add_route("/api/v0/auth/", Authentication())
+    api.add_route("/api/v0/alarms/", AlarmsResource())
     return api

--- a/server/hooks.py
+++ b/server/hooks.py
@@ -30,3 +30,26 @@ def authorization_required(req, resp, resource, params):
         raise falcon.HTTPUnauthorized("Incorrect authentication credentials")
 
     params["token"] = token
+
+
+def code_required(req, resp, resource, params):
+    """Require Elmo System `code` to obtain a Global System Lock.
+    The `code` field is part of the payload and is used everywhere in this
+    library before making any action.
+
+    When this hook is used, the `code` field is injected as a kwarg in the
+    responder function.
+
+    Args:
+        req: Falcon `Request` object
+        resp: Falcon `Response` object
+        resource: Falcon `Resource` after routing
+        params: Parameters to pass to a responder function
+    Raises:
+        HTTPBadRequest: if the `code` field is missing
+    """
+    code = req.media.get("code")
+    if code is None:
+        raise falcon.HTTPBadRequest(description="`code` is a required field")
+
+    params["code"] = code

--- a/server/resources.py
+++ b/server/resources.py
@@ -83,7 +83,7 @@ class AlarmsResource(object):
             HTTPBadRequest: if the request misses mandatory fields
             HTTPServiceUnavailable: if the Elmo System returns a server error
         Returns:
-            A JSON response with the access token.
+            A JSON response with the alarms status.
         """
         code = req.media.get("code")
         if code is None:
@@ -111,3 +111,51 @@ class AlarmsResource(object):
 
         resp.status = falcon.HTTP_200
         resp.media = {"alarms_armed": True}
+
+    def on_delete(self, req, resp, token):
+        """Disarm all alarms after gaining the system lock. Once the operation is
+        completed with success, the system lock is released.
+        The endpoint requires an `Authorization` header with a valid bearer
+        token.
+
+        Expected request:
+        {
+            "code": "str"
+        }
+
+        Args:
+            req: Falcon `Request` object
+            resp: Falcon `Response` object
+            token: Bearer token that must be used to make the client request
+        Raises:
+            HTTPBadRequest: if the request misses mandatory fields
+            HTTPServiceUnavailable: if the Elmo System returns a server error
+        Returns:
+            A JSON response with the alarms status.
+        """
+        code = req.media.get("code")
+        if code is None:
+            raise falcon.HTTPBadRequest(description="`code` is a required field")
+
+        # Initialize the client with a bearer token
+        client = ElmoClient(settings.base_url, settings.vendor)
+        client._session_id = token
+
+        try:
+            with client.lock(code):
+                client.disarm()
+        except PermissionDenied:
+            raise falcon.HTTPUnauthorized(
+                description="The bearer token is invalid or expired"
+            )
+        except APIException as e:
+            # This status may lead to a case where the system is locked.
+            # The global system lock is automatically released after one
+            # minute. Unfortunately it's not possible to recover this state
+            # other than providing credentials in every call (making useless
+            # the bearer token).
+            log.error("503 ServiceUnavailable: {}".format(e))
+            raise falcon.HTTPServiceUnavailable(description="".format(e))
+
+        resp.status = falcon.HTTP_200
+        resp.media = {"alarms_armed": False}

--- a/server/resources.py
+++ b/server/resources.py
@@ -5,6 +5,7 @@ from elmo.api.client import ElmoClient
 from elmo.api.exceptions import APIException, PermissionDenied
 
 from .conf import settings
+from .hooks import authorization_required
 
 
 log = logging.getLogger(__name__)
@@ -14,7 +15,7 @@ class Authentication(object):
     """Authentication endpoint to retrieve an access token.
 
     Endpoints:
-        POST /api/v1/auth/
+        POST /api/v0/auth/
     """
 
     def on_post(self, req, resp):
@@ -52,3 +53,61 @@ class Authentication(object):
 
         resp.media = {"access_token": token}
         resp.status = falcon.HTTP_200
+
+
+@falcon.before(authorization_required)
+class AlarmsResource(object):
+    """Alarms resource to arm/disarm all Elmo System alarms.
+
+    Endpoints:
+        PUT /api/v0/alarms/
+        DELETE /api/v0/alarms/
+    """
+
+    def on_put(self, req, resp, token):
+        """Arm all alarms after gaining the system lock. Once the operation is
+        completed with success, the system lock is released.
+        The endpoint requires an `Authorization` header with a valid bearer
+        token.
+
+        Expected request:
+        {
+            "code": "str"
+        }
+
+        Args:
+            req: Falcon `Request` object
+            resp: Falcon `Response` object
+            token: Bearer token that must be used to make the client request
+        Raises:
+            HTTPBadRequest: if the request misses mandatory fields
+            HTTPServiceUnavailable: if the Elmo System returns a server error
+        Returns:
+            A JSON response with the access token.
+        """
+        code = req.media.get("code")
+        if code is None:
+            raise falcon.HTTPBadRequest(description="`code` is a required field")
+
+        # Initialize the client with a bearer token
+        client = ElmoClient(settings.base_url, settings.vendor)
+        client._session_id = token
+
+        try:
+            with client.lock(code):
+                client.arm()
+        except PermissionDenied:
+            raise falcon.HTTPUnauthorized(
+                description="The bearer token is invalid or expired"
+            )
+        except APIException as e:
+            # This status may lead to a case where the system is locked.
+            # The global system lock is automatically released after one
+            # minute. Unfortunately it's not possible to recover this state
+            # other than providing credentials in every call (making useless
+            # the bearer token).
+            log.error("503 ServiceUnavailable: {}".format(e))
+            raise falcon.HTTPServiceUnavailable(description="".format(e))
+
+        resp.status = falcon.HTTP_200
+        resp.media = {"alarms_armed": True}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import falcon
 
 from falcon import testing
 from server.api import create
-from server.hooks import authorization_required
+from server.hooks import authorization_required, code_required
 
 
 @pytest.fixture
@@ -16,12 +16,19 @@ def client():
 def hooks_client():
     """Testing API client with a fake app"""
 
-    class Responder(object):
+    class AuthorizationResponder(object):
         @falcon.before(authorization_required)
         def on_get(self, req, resp, token):
             resp.media = {"token": token}
             resp.status = falcon.HTTP_200
 
+    class CodeResponder(object):
+        @falcon.before(code_required)
+        def on_get(self, req, resp, code):
+            resp.media = {"code": code}
+            resp.status = falcon.HTTP_200
+
     api = falcon.API()
-    api.add_route("/hooks/authorization_required", Responder())
+    api.add_route("/hooks/authorization_required", AuthorizationResponder())
+    api.add_route("/hooks/code_required", CodeResponder())
     return testing.TestClient(api)

--- a/tests/test_alarms.py
+++ b/tests/test_alarms.py
@@ -1,0 +1,65 @@
+from elmo.api.exceptions import APIException, PermissionDenied
+
+
+def test_alarms_wrong_mimetype(client):
+    """Should return 415 if JSON is not used"""
+    result = client.simulate_put(
+        "/api/v0/alarms",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393",
+        },
+        body="code=1234567890",
+    )
+    assert result.status_code == 415
+
+
+def test_alarm_missing_code(client):
+    """Should return 400 if the code is missing from the payload"""
+    result = client.simulate_put(
+        "/api/v0/alarms",
+        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
+        json={},
+    )
+    assert result.status_code == 400
+
+
+def test_alarm_successful_armed(mocker, client):
+    """Should return 200 if all alarms have been activated"""
+    mock = mocker.patch("server.resources.ElmoClient")
+    instance = mock.return_value
+
+    result = client.simulate_put(
+        "/api/v0/alarms",
+        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
+        json={"code": "1234567890"},
+    )
+    instance.lock.assert_called_once_with("1234567890")
+    assert instance.arm.call_count == 1
+    assert instance._session_id == "127d9a48-927a-43f3-a3e3-842f3f2b7393"
+    assert result.status_code == 200
+    assert result.json == {"alarms_armed": True}
+
+
+def test_alarm_invalid_expired_token(mocker, client):
+    """Should return 200 if all alarms have been activated"""
+    mocker.patch("server.resources.ElmoClient.lock", side_effect=PermissionDenied)
+
+    result = client.simulate_put(
+        "/api/v0/alarms",
+        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
+        json={"code": "1234567890"},
+    )
+    assert result.status_code == 401
+
+
+def test_alarm_api_exception(mocker, client):
+    """Should return 200 if all alarms have been activated"""
+    mocker.patch("server.resources.ElmoClient.lock", side_effect=APIException)
+
+    result = client.simulate_put(
+        "/api/v0/alarms",
+        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
+        json={"code": "1234567890"},
+    )
+    assert result.status_code == 503

--- a/tests/test_alarms.py
+++ b/tests/test_alarms.py
@@ -14,16 +14,6 @@ def test_alarms_wrong_mimetype(client):
     assert result.status_code == 415
 
 
-def test_alarm_missing_code(client):
-    """Should return 400 if the code is missing from the payload"""
-    result = client.simulate_put(
-        "/api/v0/alarms",
-        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
-        json={},
-    )
-    assert result.status_code == 400
-
-
 def test_alarm_successful_armed(mocker, client):
     """Should return 200 if all alarms have been activated"""
     mock = mocker.patch("server.resources.ElmoClient")
@@ -76,16 +66,6 @@ def test_disarm_wrong_mimetype(client):
         body="code=1234567890",
     )
     assert result.status_code == 415
-
-
-def test_disarm_missing_code(client):
-    """Should return 400 if the code is missing from the payload"""
-    result = client.simulate_delete(
-        "/api/v0/alarms",
-        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
-        json={},
-    )
-    assert result.status_code == 400
 
 
 def test_disarm_successful_armed(mocker, client):

--- a/tests/test_alarms.py
+++ b/tests/test_alarms.py
@@ -63,3 +63,67 @@ def test_alarm_api_exception(mocker, client):
         json={"code": "1234567890"},
     )
     assert result.status_code == 503
+
+
+def test_disarm_wrong_mimetype(client):
+    """Should return 415 if JSON is not used"""
+    result = client.simulate_delete(
+        "/api/v0/alarms",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393",
+        },
+        body="code=1234567890",
+    )
+    assert result.status_code == 415
+
+
+def test_disarm_missing_code(client):
+    """Should return 400 if the code is missing from the payload"""
+    result = client.simulate_delete(
+        "/api/v0/alarms",
+        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
+        json={},
+    )
+    assert result.status_code == 400
+
+
+def test_disarm_successful_armed(mocker, client):
+    """Should return 200 if all alarms have been activated"""
+    mock = mocker.patch("server.resources.ElmoClient")
+    instance = mock.return_value
+
+    result = client.simulate_delete(
+        "/api/v0/alarms",
+        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
+        json={"code": "1234567890"},
+    )
+    instance.lock.assert_called_once_with("1234567890")
+    assert instance.disarm.call_count == 1
+    assert instance._session_id == "127d9a48-927a-43f3-a3e3-842f3f2b7393"
+    assert result.status_code == 200
+    assert result.json == {"alarms_armed": False}
+
+
+def test_disarm_invalid_expired_token(mocker, client):
+    """Should return 200 if all alarms have been activated"""
+    mocker.patch("server.resources.ElmoClient.lock", side_effect=PermissionDenied)
+
+    result = client.simulate_delete(
+        "/api/v0/alarms",
+        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
+        json={"code": "1234567890"},
+    )
+    assert result.status_code == 401
+
+
+def test_disarm_api_exception(mocker, client):
+    """Should return 200 if all alarms have been activated"""
+    mocker.patch("server.resources.ElmoClient.lock", side_effect=APIException)
+
+    result = client.simulate_delete(
+        "/api/v0/alarms",
+        headers={"Authorization": "Bearer 127d9a48-927a-43f3-a3e3-842f3f2b7393"},
+        json={"code": "1234567890"},
+    )
+    assert result.status_code == 503

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -24,3 +24,18 @@ def test_authorization_success(hooks_client):
     result = hooks_client.simulate_get("/hooks/authorization_required", headers=headers)
     assert result.status_code == 200
     assert result.json == {"token": "127d9a48-927a-43f3-a3e3-842f3f2b7393"}
+
+
+def test_code_is_present(hooks_client):
+    """Should return 200 if the code is present in the payload"""
+    result = hooks_client.simulate_get(
+        "/hooks/code_required", json={"code": "1234567890"}
+    )
+    assert result.status_code == 200
+    assert result.json == {"code": "1234567890"}
+
+
+def test_code_is_not_present(hooks_client):
+    """Should return 400 if the code is missing from the payload"""
+    result = hooks_client.simulate_get("/hooks/code_required", json={})
+    assert result.status_code == 400


### PR DESCRIPTION
### Overview

Closes #7 

* Adds `authorization_required` hook to retrieve the bearer token from the `Authorization` header
* Adds `code_required` hook to retrieve the `code` field from the payload
* `AlarmsResource` offers two endpoints to `ARM` and `DISARM` all alarms.

### Endpoints

```
PUT /api/v0/alarms/     # Arm all alarms
DELETE /api/v0/alarms/  # Disarm all alarms
```