### PR TITLE
AppEngine deployment template

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -107,3 +107,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# AppEngine config
+cli.py

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# AppEngine config
+app.yaml

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,0 @@
-runtime: python37
-handlers:
-- url: /.*
-  script: auto
-  secure: always
-  redirect_http_response_code: 301

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,38 @@
+import click
+
+
+APP_YAML_TEMPLATE = """runtime: python37
+env_variables:
+  ELMO_BASE_URL: '{BASE_URL}'
+  ELMO_VENDOR: '{VENDOR}'
+handlers:
+- url: /.*
+  script: auto
+  secure: always
+  redirect_http_response_code: 301
+"""
+
+
+@click.command()
+@click.argument("base_url")
+@click.argument("vendor")
+def generate_app_yaml(base_url, vendor):
+    """Use APP_YAML_TEMPLATE to generate app.yaml for AppEngine deployments.
+
+    Args:
+        base_url: defines ELMO_BASE_URL env variable in AppEngine config.
+        vendor: defines ELMO_VENDOR env variable in AppEngine config.
+    Returns:
+        Writes `app.yaml` file in the current folder.
+    """
+    print("Writing the following deployment config to disk:")
+    app_yaml = APP_YAML_TEMPLATE.format(BASE_URL=base_url, VENDOR=vendor)
+    print(app_yaml)
+
+    with open("app.yaml", "w") as f:
+        f.write(app_yaml)
+    print("Done! You can deploy the service with `gcloud app deploy`")
+
+
+if __name__ == "__main__":
+    generate_app_yaml()

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,4 +1,5 @@
 black
+click
 codecov
 flake8
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ attrs==19.1.0             # via black, pytest
 black==19.3b0
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
-click==7.0                # via black
+click==7.0
 codecov==2.0.15
 coverage==4.5.3           # via codecov, pytest-cov
 entrypoints==0.3          # via flake8
@@ -29,7 +29,7 @@ pytest==4.5.0
 requests==2.22.0          # via codecov
 six==1.12.0               # via pytest, tox
 toml==0.10.0              # via black, tox
-tox==3.11.1
-urllib3==1.25.2           # via requests
+tox==3.12.1
+urllib3==1.25.3           # via requests
 virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ pycparser==2.19           # via cffi
 pyopenssl==19.0.0         # via requests
 requests[security]==2.22.0
 six==1.12.0               # via cryptography, pyopenssl
-urllib3==1.25.2           # via requests
+urllib3==1.25.3           # via requests


### PR DESCRIPTION
### Overview

Elmo server relies on `ELMO_BASE_URL` and `ELMO_VENDOR` env variables. To avoid committing them in the repo, a `cli.py` tool is available so that it can be dynamically generated and deployed on AppEngine.

Usage:
```bash
$ pip install -r requirements-dev.txt
$ python cli.py https://example.com vendor_name
``` 